### PR TITLE
Add test cases for converting F# and A# to numeric

### DIFF
--- a/test/key/to_numeric.test.js
+++ b/test/key/to_numeric.test.js
@@ -25,6 +25,11 @@ const examples = {
     'Gb': 'b3',
     'E': 'b2',
   },
+
+  'B': {
+    'F#': '5',
+    'A#': '7',
+  },
 };
 
 describe('Key', () => {


### PR DESCRIPTION
The bug itself seems already to have been resolved, but this PR adds testcases for those specific keys.

Resolves #23