### PR TITLE
Implement Song#setCapo and Song#setKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChordSheetJS [![Code Climate](https://codeclimate.com/github/PraiseCharts/ChordChartJS/badges/gpa.svg)](https://codeclimate.com/github/PraiseCharts/ChordChartJS)
+# ChordChartJS [![Code Climate](https://codeclimate.com/github/PraiseCharts/ChordChartJS/badges/gpa.svg)](https://codeclimate.com/github/PraiseCharts/ChordChartJS)
 
 A JavaScript library for parsing and formatting chord sheets
 
@@ -469,6 +469,9 @@ Inherits from <a href="#ChordSheetParser">ChordSheetParser</a></p>
 <dt><a href="#TRANSPOSE">TRANSPOSE</a> : <code>string</code></dt>
 <dd><p>Transpose meta directive. See: <a href="https://www.chordpro.org/chordpro/directives-transpose/">https://www.chordpro.org/chordpro/directives-transpose/</a></p>
 </dd>
+<dt><a href="#NEW_KEY">NEW_KEY</a> : <code>string</code></dt>
+<dd><p>New Key meta directive. See: <a href="https://github.com/PraiseCharts/ChordChartJS/issues/53">https://github.com/PraiseCharts/ChordChartJS/issues/53</a></p>
+</dd>
 <dt><a href="#YEAR">YEAR</a> : <code>string</code></dt>
 <dd><p>Year meta directive. See <a href="https://www.chordpro.org/chordpro/directives-year/">https://www.chordpro.org/chordpro/directives-year/</a></p>
 </dd>
@@ -756,6 +759,8 @@ Represents a song in a chord sheet. Currently a chord sheet can only have one so
     * [.bodyParagraphs](#Song+bodyParagraphs) ⇒ [<code>Array.&lt;Paragraph&gt;</code>](#Paragraph)
     * ~~[.metaData](#Song+metaData) ⇒~~
     * [.clone()](#Song+clone) ⇒ [<code>Song</code>](#Song)
+    * [.setCapo(capo)](#Song+setCapo) ⇒ [<code>Song</code>](#Song)
+    * [.setKey(key)](#Song+setKey) ⇒ [<code>Song</code>](#Song)
 
 <a name="new_Song_new"></a>
 
@@ -818,6 +823,35 @@ Returns a deep clone of the song
 
 **Kind**: instance method of [<code>Song</code>](#Song)  
 **Returns**: [<code>Song</code>](#Song) - The cloned song  
+<a name="Song+setCapo"></a>
+
+### song.setCapo(capo) ⇒ [<code>Song</code>](#Song)
+Returns a copy of the song with the capo value set to the specified capo. It changes:
+- the value for `capo` in the `metadata` set
+- any existing `capo` directive)
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - The changed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| capo | <code>number</code> \| <code>null</code> | the capo. Passing `null` will: - remove the current key from `metadata` - remove any `capo` directive |
+
+<a name="Song+setKey"></a>
+
+### song.setKey(key) ⇒ [<code>Song</code>](#Song)
+Returns a copy of the song with the key set to the specified key. It changes:
+- the value for `key` in the `metadata` set
+- any existing `key` directive
+- all chords, those are transposed according to the distance between the current and the new key
+
+**Kind**: instance method of [<code>Song</code>](#Song)  
+**Returns**: [<code>Song</code>](#Song) - The changed song  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | The new key. |
+
 <a name="Tag"></a>
 
 ## Tag
@@ -1529,6 +1563,12 @@ Title meta directive. See https://www.chordpro.org/chordpro/directives-title/
 
 ## TRANSPOSE : <code>string</code>
 Transpose meta directive. See: https://www.chordpro.org/chordpro/directives-transpose/
+
+**Kind**: global constant  
+<a name="NEW_KEY"></a>
+
+## NEW\_KEY : <code>string</code>
+New Key meta directive. See: https://github.com/PraiseCharts/ChordChartJS/issues/53
 
 **Kind**: global constant  
 <a name="YEAR"></a>

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -1,4 +1,4 @@
-# ChordSheetJS [![Build Status](https://travis-ci.org/martijnversluis/ChordSheetJS.svg?branch=master)](https://travis-ci.org/martijnversluis/ChordSheetJS) [![npm version](https://badge.fury.io/js/chordsheetjs.svg)](https://badge.fury.io/js/chordsheetjs) [![Code Climate](https://codeclimate.com/github/martijnversluis/ChordSheetJS/badges/gpa.svg)](https://codeclimate.com/github/martijnversluis/ChordSheetJS)
+# ChordChartJS [![Code Climate](https://codeclimate.com/github/PraiseCharts/ChordChartJS/badges/gpa.svg)](https://codeclimate.com/github/PraiseCharts/ChordChartJS)
 
 A JavaScript library for parsing and formatting chord sheets
 

--- a/src/chord_sheet/chord_lyrics_pair.js
+++ b/src/chord_sheet/chord_lyrics_pair.js
@@ -42,6 +42,13 @@ class ChordLyricsPair {
   toString() {
     return `ChordLyricsPair(chords=${this.chords}, lyrics=${this.lyrics})`;
   }
+
+  set(properties) {
+    return new this.constructor(
+      properties.chords || this.chords,
+      properties.lyrics || this.lyrics,
+    );
+  }
 }
 
 export default ChordLyricsPair;

--- a/src/chord_sheet/line.js
+++ b/src/chord_sheet/line.js
@@ -63,8 +63,19 @@ class Line {
    * @returns {Line}
    */
   clone() {
+    return this.mapItems(null);
+  }
+
+  mapItems(func) {
     const clonedLine = new Line();
-    clonedLine.items = this.items.map((item) => item.clone());
+
+    clonedLine.items = this.items
+      .map((item) => {
+        const clonedItem = item.clone();
+        return func ? func(clonedItem) : clonedItem;
+      })
+      .filter((item) => item);
+
     clonedLine.type = this.type;
     return clonedLine;
   }
@@ -131,6 +142,16 @@ class Line {
     const comment = (content instanceof Comment) ? content : new Comment(content);
     this.items.push(comment);
     return comment;
+  }
+
+  set(properties) {
+    return new this.constructor(
+      {
+        type: this.type,
+        items: this.items,
+        ...properties,
+      },
+    );
   }
 }
 

--- a/src/chord_sheet/metadata.js
+++ b/src/chord_sheet/metadata.js
@@ -37,6 +37,10 @@ class Metadata {
       });
   }
 
+  contains(key) {
+    return key in this;
+  }
+
   add(key, value) {
     if (isReadonlyTag(key)) {
       return;
@@ -59,6 +63,14 @@ class Metadata {
     }
 
     this[key] = [currentValue, value];
+  }
+
+  set(key, value) {
+    if (value) {
+      this[key] = value;
+    } else {
+      delete this[key];
+    }
   }
 
   /**

--- a/src/chord_sheet/tag.js
+++ b/src/chord_sheet/tag.js
@@ -261,7 +261,7 @@ class Tag {
    */
   get value() {
     if (this._value) {
-      return this._value.trim();
+      return `${this._value}`.trim();
     }
 
     return this._value || null;
@@ -296,11 +296,15 @@ class Tag {
    * @returns {Tag} The cloned tag
    */
   clone() {
-    return new Tag(this.name, this.value);
+    return new Tag(this._originalName, this.value);
   }
 
   toString() {
     return `Tag(name=${this.name}, value=${this.name})`;
+  }
+
+  set({ value }) {
+    return new Tag(this._originalName, value);
   }
 }
 

--- a/src/formatter/templates/html_div_formatter.handlebars
+++ b/src/formatter/templates/html_div_formatter.handlebars
@@ -15,7 +15,7 @@
             <div class="{{lineClasses line}}">
               {{~#each items as |item|~}}
                 {{~#if (isChordLyricsPair item)~}}
-                  <div class="column"><div class="chord">{{renderChord chords line.key @root.song.key line.transposeKey}}</div><div class="lyrics">{{lyrics}}</div></div>
+                  <div class="column"><div class="chord">{{renderChord chords line.key line.transposeKey @root.song}}</div><div class="lyrics">{{lyrics}}</div></div>
                 {{~/if~}}
 
                 {{~#if (isTag item)~}}

--- a/src/formatter/templates/html_table_formatter.handlebars
+++ b/src/formatter/templates/html_table_formatter.handlebars
@@ -18,7 +18,7 @@
                   <tr>
                     {{~#each items as |item|~}}
                       {{~#if (isChordLyricsPair item)~}}
-                        <td class="chord">{{renderChord chords line.key @root.song.key line.transposeKey}}</td>
+                        <td class="chord">{{renderChord chords line.key line.transposeKey @root.song}}</td>
                       {{~/if~}}
                     {{~/each~}}
                   </tr>

--- a/src/formatter/text_formatter.js
+++ b/src/formatter/text_formatter.js
@@ -89,7 +89,7 @@ class TextFormatter {
   }
 
   chordLyricsPairLength(chordLyricsPair, line) {
-    const chords = renderChord(chordLyricsPair.chords, line.key, this.song.key, line.transposeKey);
+    const chords = renderChord(chordLyricsPair.chords, line.key, line.transposeKey, this.song);
     const { lyrics } = chordLyricsPair;
     const chordsLength = (chords || '').length;
     const lyricsLength = (lyrics || '').length;
@@ -107,7 +107,7 @@ class TextFormatter {
     }
 
     if (item instanceof ChordLyricsPair) {
-      const chords = renderChord(item.chords, line.key, this.song.key, line.transposeKey);
+      const chords = renderChord(item.chords, line.key, line.transposeKey, this.song);
       return padLeft(chords, this.chordLyricsPairLength(item, line));
     }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,8 @@
 import Chord from './chord';
-import { presence } from './utilities';
+import { isPresent } from './utilities';
 import Key from './key';
 
-function transposeDistance(transposeKey, songKey) {
+export function transposeDistance(transposeKey, songKey) {
   if (/^\d+$/.test(transposeKey)) {
     return parseInt(transposeKey, 10);
   }
@@ -10,21 +10,31 @@ function transposeDistance(transposeKey, songKey) {
   return Key.distance(songKey, transposeKey);
 }
 
-/* eslint import/prefer-default-export: 0 */
-export function renderChord(chord, lineKey, songKey, transposeKey) {
-  const distance = presence(transposeKey) ? transposeDistance(transposeKey, songKey) : 0;
+function chordTransposeDistance(capo, transposeKey, songKey) {
+  let transpose = -1 * (capo || 0);
+
+  if (isPresent(transposeKey) && isPresent(songKey)) {
+    transpose += transposeDistance(transposeKey, songKey);
+  }
+  return transpose;
+}
+
+export function renderChord(chord, lineKey, transposeKey, song) {
   let chordObj = Chord.parse(chord);
+  const { capo, key: songKey } = song;
 
   if (!chordObj) {
     return chord;
   }
 
-  if (presence(transposeKey) && presence(songKey)) {
-    chordObj = chordObj.transpose(distance).useModifier(transposeKey.modifier);
+  chordObj = chordObj.transpose(chordTransposeDistance(capo, transposeKey, songKey));
+
+  if (isPresent(transposeKey)) {
+    chordObj = chordObj.useModifier(transposeKey.modifier);
   }
 
-  if (presence(lineKey)) {
-    chordObj = chordObj.normalize(lineKey); // normalize by key functionality not yet implemented.
+  if (isPresent(lineKey)) {
+    chordObj = chordObj.normalize(lineKey);
   }
 
   return chordObj.toString();

--- a/test/integration/changing_capo.test.js
+++ b/test/integration/changing_capo.test.js
@@ -1,0 +1,64 @@
+import { ChordProFormatter, ChordProParser } from '../../src';
+
+describe('changing the capo of an existing song', () => {
+  it('updates the capo directive', () => {
+    const chordpro = `
+{capo: 7}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('adds the capo directive', () => {
+    const chordpro = `
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('adds the capo directive after the key directive', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: C}
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(3);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+
+  it('removes the capo directive', () => {
+    const chordpro = `
+{key: C}
+{capo: 3}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setCapo(null);
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+});

--- a/test/integration/changing_key.test.js
+++ b/test/integration/changing_key.test.js
@@ -1,0 +1,18 @@
+import { ChordProFormatter, ChordProParser } from '../../src';
+
+describe('changing the key of an existing song', () => {
+  it('updates the key directive', () => {
+    const chordpro = `
+{key: C}
+Let it [Am]be, let it [C/G]be, let it [F]be, let it [C]be`.substring(1);
+
+    const changedSheet = `
+{key: D}
+Let it [Bm]be, let it [D/A]be, let it [G]be, let it [D]be`.substring(1);
+
+    const song = new ChordProParser().parse(chordpro);
+    const updatedSong = song.setKey('D');
+
+    expect(new ChordProFormatter().format(updatedSong)).toEqual(changedSheet);
+  });
+});

--- a/test/parser/chord_pro_parser.test.js
+++ b/test/parser/chord_pro_parser.test.js
@@ -213,7 +213,7 @@ This part is [G]key
     const song = parser.parse(chordSheetWithTranspose);
     const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].key);
 
-    expect(keys[0]).toBe(null);
+    expect(keys[0]).toBe('A');
     expect(keys[1]).toEqual('D');
     expect(keys[2]).toEqual('G');
   });
@@ -238,7 +238,7 @@ This part is [G]key
     const keys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].key);
     const transposeKeys = song.bodyParagraphs.map((paragraph) => paragraph.lines[0].transposeKey);
 
-    expect(keys[0]).toBe(null);
+    expect(keys[0]).toBe('A');
     expect(transposeKeys[1]).toEqual('4');
     expect(keys[1]).toEqual('D');
     expect(transposeKeys[2]).toEqual('D');


### PR DESCRIPTION
`setCapo` changes the song capo, both in `metadata` and the `capo` directive.
`setKey` changes the song key in `metadata` and the `key` directive, and transposes all chords according to the distance between the current key and the new key.

Related to #22 